### PR TITLE
android.R.id.content

### DIFF
--- a/app/src/main/java/com/example/usuario/dynamicfragment/MainActivity.java
+++ b/app/src/main/java/com/example/usuario/dynamicfragment/MainActivity.java
@@ -21,7 +21,7 @@ public class MainActivity extends AppCompatActivity implements FragmentA.Fragmen
         {
             fragmenta = new FragmentA();
             FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
-            //android.R.id.content es el id del FrameLayout de MainActivty
+            //android.R.id.content hace referencia al contenedor de la activity en la que estamos (por tanto no necesitamos ponerle un id)
             fragmentTransaction.add(android.R.id.content, fragmenta, FragmentA.TAG);
             fragmentTransaction.commit();
         }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,7 +5,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:id="@+id/content"
     tools:context=".MainActivity">
 
 


### PR DESCRIPTION
`android.R.id.content` hace referencia al contenedor raiz de la activity en la que estamos, por tanto no necesitamos ponerle un id a dicha activity, que en todo caso, llamandose _content_ accederiamos con `R.id.content`.
  

Extracto de StackOverflow:
> android.R.id.content gives you the root element of a view, without having to know its actual name/type/ID